### PR TITLE
Improve the current pagination style of demo with different position

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,26 +1,10 @@
 import React from 'react'
-import Pagination from './pagination'
-import data from './mockData'
-import './assets/App.scss'
+import Example from './demo/Example';
 
-const App = () => (
-  <div className="container">
-    <h1>Custom React Pages</h1>
-    <Pagination
-      itemsPerPage={5}
-      activePageStyle={{ backgroundColor: '#00b9f2', color: 'white' }}
-      next="next"
-      prev="prev"
-      data={data}
-      pageButtons={10}
-      onePage={(item, index) => (
-        <div key={index} className="oneItem">
-          <div>{item.firstName}</div>
-          <div>{item.lastName}</div>
-        </div>
-      )}
-    />
-  </div>
-)
+const App = () => {
+  return (
+    <Example />
+  )
+}
 
 export default App

--- a/src/assets/App.scss
+++ b/src/assets/App.scss
@@ -1,6 +1,5 @@
 %fullDimensions {
   width: 100%;
-  height: 100%;
   margin: auto;
 }
 %flex-row {
@@ -27,9 +26,6 @@ html {
           text-align: center;
         }
         .pagination-container {
-          margin: auto;
-          height: 100%;
-          width: 50%;
           display: flex;
           flex-direction: column;
           .oneItem {
@@ -40,17 +36,38 @@ html {
             }
           }
           .pagination-buttons {
-            @extend %flex-row;
-            .pages,
-            .arrows {
-              @extend %flex-row;
-              button {
-                color: #00b9f2;
-                outline: none;
-                margin: 5px;
-                width: 40px;
-              }
-            }
+            display: flex;
+            flex-direction: row;
+            padding: 20px 50px 20px 0px;
+          }
+          
+          .pagination-buttons button {
+            height: 36px;
+            cursor: pointer;
+            font-size: 16px;
+          }
+          .pages {
+            display: flex;
+            flex-direction: row;
+          }
+          
+          .pages button {
+            border-bottom: 1px solid #d5d4d0;
+            border-top: 1px solid #d5d4d0;
+          }
+          
+          button#prev {
+            border-bottom: 1px solid #d5d4d0;
+            border-top: 1px solid #d5d4d0;
+            border-bottom-left-radius: 5px;
+            border-top-left-radius: 5px;
+          }
+          
+          button#next {
+            border-bottom: 1px solid #d5d4d0;
+            border-top: 1px solid #d5d4d0;
+            border-bottom-right-radius: 5px;
+            border-top-right-radius: 5px;
           }
         }
       }

--- a/src/assets/paginationOnlyStyle.css
+++ b/src/assets/paginationOnlyStyle.css
@@ -1,0 +1,40 @@
+.pagination-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.pagination-buttons {
+  display: flex;
+  flex-direction: row;
+  padding: 20px 50px 20px 0px;
+}
+
+.pagination-buttons button {
+  height: 36px;
+  cursor: pointer;
+  font-size: 16px;
+}
+.pages {
+  display: flex;
+  flex-direction: row;
+}
+
+.pages button {
+  border-bottom: 1px solid #d5d4d0;
+  border-top: 1px solid #d5d4d0;
+}
+
+button#prev {
+  border-bottom: 1px solid #d5d4d0;
+  border-top: 1px solid #d5d4d0;
+  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
+}
+
+button#next {
+  border-bottom: 1px solid #d5d4d0;
+  border-top: 1px solid #d5d4d0;
+  border-bottom-right-radius: 5px;
+  border-top-right-radius: 5px;
+}

--- a/src/demo/Example.js
+++ b/src/demo/Example.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import Pagination from './../pagination';
+import data from './../mockData';
+import '../assets/App.scss';
+
+const App = () => {
+  const topLeftPagination = {
+    paginationContainer: {
+      flexDirection: 'column-reverse',
+    },
+    paginationButtons: {
+      marginRight: 'auto',
+    }
+  };
+
+  const topRightPagination = {
+    paginationContainer: {
+      flexDirection: 'column-reverse',
+    },
+    paginationButtons: {
+      marginLeft: 'auto',
+    }
+  };
+
+  const bottomLeftPagination = {
+    paginationContainer: {
+      flexDirection: 'column',
+    },
+    paginationButtons: {
+      marginRight: 'auto',
+    }
+  };
+
+  const bottomRightPagination = {
+    paginationContainer: {
+      flexDirection: 'column',
+    },
+    paginationButtons: {
+      marginLeft: 'auto',
+    }
+  };
+  const centerTopPagination = {
+    paginationContainer: {
+      flexDirection: 'column-reverse',
+    },
+    paginationButtons: {
+      margin: 'auto',
+    }
+  };
+  const centertBottomPagination = {
+    paginationContainer: {
+      flexDirection: 'column',
+    },
+    paginationButtons: {
+      margin: 'auto',
+    }
+  };
+
+  return (
+    <div className="container">
+      <h1>Custom React Pages</h1>
+      <Pagination
+        itemsPerPage={5}
+        activePageStyle={{ backgroundColor: '#00b9f2', color: 'white' }}
+        next="next"
+        prev="prev"
+        data={data}
+        pageButtons={10}
+        onePage={(item, index) => (
+          <div key={index} className="oneItem">
+            <div>{item.firstName}</div>
+            <div>{item.lastName}</div>
+          </div>
+        )}
+        paginationContainer={topLeftPagination.paginationContainer}
+        paginationButtons={topLeftPagination.paginationButtons}
+      />
+    </div>
+  )
+}
+
+export default App

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -15,6 +15,8 @@ export default ({
   activePageStyle,
   pageName,
   pageButtons,
+  paginationContainer,
+  paginationButtons,
 }) => {
   const [pageNo, setPageNo] = useState(0)
 
@@ -31,10 +33,10 @@ export default ({
           pageNo + Math.round(pageButtons / 2)
         ))
   return (
-    <div className="pagination-container">
+    <div className="pagination-container" style={paginationContainer}>
       {data.length &&
         (pages[pageNo] || pages[0]).map((item, index) => onePage(item, index))}
-      <div className="pagination-buttons">
+      <div className="pagination-buttons" style={paginationButtons} >
         <div className="arrows">
           <button
             id="prev"


### PR DESCRIPTION
#### What does this PR do?
The PR helps different users to re-use pagination demo code into their work.

#### Description of Task to be completed?
- refactor current code
- add option style to pagination component
- add global and customizable style
- add paginate on top - bottom - left - right -center position of the page

#### How should this be manually tested?
- git clone 
- npm i
- npm run dev
- git checkout paginate-user-demo

#### Any background context you want to provide?
The demo code was already written. I have improved in the way it will look nicer to users. If not, users will edit `example.css` to fit their styles. Moreover, User has the full right to position to pagination.

#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)


<img width="1440" alt="Screen Shot 2020-02-16 at 17 32 48" src="https://user-images.githubusercontent.com/33821734/74607617-fca93500-50e2-11ea-95c6-3bade536662d.png">

#### Questions:
<img width="1440" alt="Screen Shot 2020-02-16 at 17 33 44" src="https://user-images.githubusercontent.com/33821734/74607620-00d55280-50e3-11ea-915f-9663a7f8241f.png">

<img width="1440" alt="Screen Shot 2020-02-16 at 17 34 37" src="https://user-images.githubusercontent.com/33821734/74607622-016de900-50e3-11ea-967e-817756362853.png">

<img width="1440" alt="Screen Shot 2020-02-16 at 17 35 12" src="https://user-images.githubusercontent.com/33821734/74607624-02067f80-50e3-11ea-9341-46d34c3ab38a.png">

<img width="1440" alt="Screen Shot 2020-02-16 at 17 36 03" src="https://user-images.githubusercontent.com/33821734/74607625-0337ac80-50e3-11ea-9909-3b67f123ce48.png">

<img width="1440" alt="Screen Shot 2020-02-16 at 17 36 38" src="https://user-images.githubusercontent.com/33821734/74607626-03d04300-50e3-11ea-97ff-c1eb1bc2b859.png">


